### PR TITLE
Resolve rendering issue where screen turns white after first frame

### DIFF
--- a/examples/animate.html
+++ b/examples/animate.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>WebGL-2D Example</title>
+  
+    <script src="../webgl-2d.js" type="text/javascript"></script>
+  
+    <script type="text/javascript">
+      document.addEventListener("DOMContentLoaded", init, false);
+
+      var cvs2D, cvsGL, ctx2D, ctxGL, width, height;
+      var frameCount = 0;
+
+      function init() {
+        cvs2D = document.getElementById("canvas2D");
+        cvsGL = document.getElementById("canvasGL");
+
+        width = cvs2D.width, height = cvs2D.height;
+
+        WebGL2D.enable(cvsGL); // adds new context "webgl-2d" to cvs
+
+        // Easily switch between regular canvas 2d context and webgl-2d
+        ctx2D = cvs2D.getContext("2d");
+        ctxGL = cvsGL.getContext("webgl-2d");
+
+      }
+
+      // Enable animation - only shows first frame :/
+      var func = function() {
+        // ctxGL.clear(ctxGL.COLOR_BUFFER_BIT | ctxGL.DEPTH_BUFFER_BIT);
+          frameCount++;
+          draw(ctxGL);
+          draw(ctx2D);
+          // setTimeout(func, 500);
+      }
+      setTimeout(func, 500);
+
+      function draw(ctx) {
+      ctx.fillStyle = "rgb(50, 0, 50)";
+      ctx.fillRect(0, 0, width, height);
+
+      ctx.save();
+        ctx.translate(width/2, height/2);
+        ctx.rotate(frameCount/100);
+        ctx.save();
+          ctx.fillStyle = "rgba(50, 255, 255, 0.1)";
+          for (var i = 0; i < 50; i++) {
+            ctx.scale(2,2);
+            ctx.fillRect(0, 0, 50, 50);
+            ctx.scale(.5, .5);
+            ctx.rotate(-2*Math.PI/50);
+          }
+        ctx.restore();
+      ctx.restore();
+      }
+      
+    </script>
+
+    <style type="text/css">
+      body, * {
+        font-family: sans-serif;
+      }
+    </style>
+  
+  </head>
+  
+  <body>
+    <h1>Example: WebGL-2D Comparison</h1>
+    <h2>beginPath, closePath, moveTo, lineTo, fill, stroke</h2>
+    <div style="float: left; margin-right: 10px;">
+      <h2>WebGL-2D</h2> 
+      <canvas id="canvasGL" width="350" height="350" style="border: 1px solid black;"></canvas>
+    </div>
+    <div style="float: left;">
+      <h2>Canvas2D</h2>
+      <canvas id="canvas2D" width="350" height="350" style="border: 1px solid black;"></canvas>
+    </div>
+  </body>
+</html>

--- a/examples/animate.html
+++ b/examples/animate.html
@@ -31,7 +31,7 @@
           frameCount++;
           draw(ctxGL);
           draw(ctx2D);
-          // setTimeout(func, 500);
+          setTimeout(func, 16);
       }
       setTimeout(func, 500);
 

--- a/webgl-2d.js
+++ b/webgl-2d.js
@@ -292,9 +292,6 @@
           gl.clearColor(1, 1, 1, 1);
           gl.clear(gl.COLOR_BUFFER_BIT); // | gl.DEPTH_BUFFER_BIT);
 
-          // Disables writing to dest-alpha
-          gl.colorMask(1,1,1,0);
-
           // Depth options
           //gl.enable(gl.DEPTH_TEST);
           //gl.depthFunc(gl.LEQUAL);


### PR DESCRIPTION
I don't know how common or widespread this issue is; I found out about it via a [SO](http://stackoverflow.com/questions/11418757/javascript-library-webgl-2d-animation-not-working) question. But, it can be duplicated on my own hardware, so I fixed it.

The color mask `(1, 1, 1, 0)` seems to be the source of the issue, but I don't particularly understand why. Simply removing the color mask seems to have no ill effect, so that's all this pull request does.

This pull request also includes an example file which reproduces the effect, and which works properly after applying the change.
